### PR TITLE
fix #31 set -O2 while Compiling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
             <options>
               <option>-std=c++0x</option>
               <option>-w</option>
+              <option>-O2</option>
               <!--<option>-Wall</option>
               <option>-Wno-sign-conversion</option>
               <option>-Wno-unused-variable</option>


### PR DESCRIPTION
原来的配置文件中没有对c++开启编译优化，开启后性能提升到正常水平（8倍左右）